### PR TITLE
fix for the "Object" as class name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 composer.phar
 composer.lock
 codecept.phar
+# netbeans project files
+nbproject

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -3,10 +3,10 @@
 namespace bmwx591\yrl;
 
 /**
- * Class Object
+ * Class BaseObject
  * @package bmwx591\yrl
  */
-abstract class Object
+abstract class BaseObject
 {
     protected $errors = [];
 

--- a/src/NestedObject.php
+++ b/src/NestedObject.php
@@ -6,7 +6,7 @@ namespace bmwx591\yrl;
  * Class NestedObject
  * @package bmwx591\yrl
  */
-abstract class NestedObject extends Object
+abstract class NestedObject extends BaseObject
 {
 
     public function isValid()

--- a/src/offer/Offer.php
+++ b/src/offer/Offer.php
@@ -2,7 +2,7 @@
 
 namespace bmwx591\yrl\offer;
 
-use bmwx591\yrl\Object;
+use bmwx591\yrl\BaseObject;
 use bmwx591\yrl\Location;
 use bmwx591\yrl\Option;
 use bmwx591\yrl\Price;
@@ -12,7 +12,7 @@ use bmwx591\yrl\SalesAgent;
  * Class Offer
  * @package bmwx591\yrl\offer
  */
-abstract class Offer extends Object
+abstract class Offer extends BaseObject
 {
     protected $internalId;
 


### PR DESCRIPTION
PHP Fatal error:  Cannot use bmwx591\yrl\Object as Object because 'Object' is a special class name